### PR TITLE
Updated upnext with timestamps

### DIFF
--- a/src/Generator.py
+++ b/src/Generator.py
@@ -63,15 +63,17 @@ def gen_upnext(video_dir, audio_dir=None, playlist=None, info_file=None):
 
 def gen_upnext_text(playlist, info_file=None):
     overlay_text = ""
-
-    #  time_index = get_time_hm()
-    # time_index += timedelta(seconds=30) # TODO: make this be the length of the upnext video
-    for item in playlist:
-        # overlay_text += time_index.strftime("%H:%M") + \
-        #     "  " + item.title + "\n\n"
-        overlay_text += '>' + \
+    time_index = get_time_hm()
+    time_index += timedelta(seconds=30)
+    for i in range(len(playlist)):
+        item = playlist[i]
+        if i == 0:
+            overlay_text += 'Next -' + \
             "  " + item.title + "\n\n"
-        # time_index += item.duration_readable
+        else:
+            overlay_text += time_index.strftime("%H:%M") + ' -' + \
+            "  " + item.title + "\n\n"
+        time_index += timedelta(seconds=(item.duration/1000))
 
     if info_file:
         overlay_text += "\n" + get_random_line(info_file)


### PR DESCRIPTION
Sorry to bump an old project, but I decided to revisit it today and wanted to offer a quick change.
I know your note said you wanted it to include the length of the next video, but I thought it would be cool if it included the time that the files would play.  IIRC this was the original intended behavior *I THINK* but I digress. 

Formatted as
Next - filename
HH:MM - filename
HH:MM - filename
etc.
