### PR TITLE
Various Fixes, default now loops again

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ usage: ComfyChannel.py [-h] [-l] [-o OUTPUT] [-ua UPNEXT_AUDIO_FILE]
 
 optional arguments:
   -h, --help            show this help message and exit
-  -l, --loop            loop playout
+  -1, --once            run playout only once
   -o OUTPUT, --output OUTPUT
                         output location (stream url)
   -ua UPNEXT_AUDIO_FILE, --upnext_audio_file UPNEXT_AUDIO_FILE

--- a/src/ComfyChannel.py
+++ b/src/ComfyChannel.py
@@ -9,6 +9,7 @@ import psutil
 import Config as c
 import Logger
 import Generator
+from datetime import datetime
 from Client import Client
 from MediaItem import MediaItem
 from Scheduler import Scheduler
@@ -31,7 +32,7 @@ def init_args():
                         action="store")
     parser.add_argument("-p", "--playout_file", help="playout config file",
                         action="store")
-    parser.add_argument("-l", "--loop", help="loop after playout file ends",
+    parser.add_argument("-1", "--once", help="only run through playout once",
                         action="store_true")
 
     args = vars(parser.parse_args())
@@ -49,8 +50,8 @@ def init_args():
         c.SERVER_DRAWTEXT_FONT_FILE = args['font_file']
     if args['playout_file']:
         c.PLAYOUT_FILE = args['playout_file']
-    if args['loop']:
-        c.LOOP = True
+    if args['once']:
+        c.LOOP = False
     return args
 
 # Exit program if signal received
@@ -102,6 +103,7 @@ def main():
 
     # Main loop
     while True:
+        c.TIME_INDEX = datetime.now()
         bumplist = Generator.gen_playlist(c.BUMP_FOLDER) # Playlist of bumps
         scheduler = Scheduler(c.PLAYOUT_FILE) # Create a schedule using full playout file
         Logger.LOGGER.log(Logger.TYPE_INFO,

--- a/src/Config.py
+++ b/src/Config.py
@@ -1,11 +1,14 @@
 # Auto-Channel configuration file
 
+# For calculating times on upnext items
+TIME_INDEX = None
+
 MAX_CONSECUTIVE_RETRIES = 3  # TODO: If several consecutive files fail, exit program
 MAX_SAME_FILE_RETRIES = 3  # Number of times to attempt playing a file before giving up
 
 PLAYOUT_FILE = 'playout.ini'
 OUTPUT_LOCATION = 'rtmp://localhost/live/stream'
-LOOP = False
+LOOP = True
 
 SCHEDULER_UPNEXT_VIDEO_FOLDER = 'upnext/video'
 SCHEDULER_UPNEXT_AUDIO_FOLDER = 'upnext/audio'


### PR DESCRIPTION
I'm back again, with a few more things. I've been using this a lot and my versions HEAVILY modified but I thought it good to merge some more from my version. 

Default now loops again, -1 or --once will play through once. This just makes more sense to me given your (perceived) original intent. 

Fixed time_index calculation. Moved it to a global on the config so updates to it remain. Also added some magic so that upnext items duration is added to it. 

Added an additional filter to the part where you list directories and sub-directories to filter out common subtitle files. The original would sometimes catch these and try to play them. 